### PR TITLE
fix(method:missing) new ruby version supports only module method miss…

### DIFF
--- a/lib/redis-slave-read/interface/base.rb
+++ b/lib/redis-slave-read/interface/base.rb
@@ -49,7 +49,7 @@ class Redis
 
         def method_missing(method, *args)
           if master.respond_to?(method)
-            define_method(method) do |*_args|
+            self.class.define_method(method) do |*_args|
               @master.send(method, *_args)
             end
             send(method, *args)


### PR DESCRIPTION
…ing and not instance